### PR TITLE
Use env vars for spreadsheet config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Environment Variables
+
+Before running the project you need to create a `.env` file in the root of the repository with the following variables:
+
+```
+REACT_APP_CLIENT_ID=your_google_client_id
+REACT_APP_SPREADSHEET_ID=your_spreadsheet_id
+REACT_APP_SHEET_NAME=your_sheet_name
+```
+
+These values are used to connect to your Google Spreadsheet.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/App.js
+++ b/src/App.js
@@ -11,9 +11,9 @@ const MoonIcon = ({ className }) => (<svg className={className} xmlns="http://ww
 
 // --- INSTRUÇÕES IMPORTANTES ---
 const SPREADSHEET_CONFIG = {
-    clientId: '375849344447-5qvtr7kho4umqb731272nt6mh8rrp9h7.apps.googleusercontent.com',
-    spreadsheetId: '15s9u9s-5UOeCA-__P1170512Y3TIIypxdKWUdSIJLzo',
-    sheetName: 'compras'
+    clientId: process.env.REACT_APP_CLIENT_ID,
+    spreadsheetId: process.env.REACT_APP_SPREADSHEET_ID,
+    sheetName: process.env.REACT_APP_SHEET_NAME,
 };
 
 // --- Componente Principal: App ---
@@ -92,8 +92,8 @@ export default function App() {
     }, [gapi, google]);
 
     const handleLogin = () => {
-        if (SPREADSHEET_CONFIG.clientId === 'SEU_CLIENT_ID_VAI_AQUI') {
-            setError("Por favor, adicione o seu Client ID no código do ficheiro App.js.");
+        if (!SPREADSHEET_CONFIG.clientId) {
+            setError("Por favor, defina REACT_APP_CLIENT_ID no ficheiro .env.");
             return;
         }
         if (tokenClient) {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders dashboard title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const title = screen.getByText(/dashboard de compras/i);
+  expect(title).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- load spreadsheet configuration from `.env`
- ignore `.env` file
- add explanation of required environment variables in README
- update failing default test to look for dashboard title

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1c1b46848324a3af8d83420ca008